### PR TITLE
Minor protoactor-go fixes

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -16,7 +16,7 @@ var extensionID = extensions.NextExtensionID()
 type Cluster struct {
 	ActorSystem    *actor.ActorSystem
 	Config         *Config
-	Gossip         Gossiper
+	Gossip         *Gossiper
 	Remote         *remote.Remote
 	PidCache       *PidCacheValue
 	MemberList     *MemberList

--- a/cluster/gossip_actor.go
+++ b/cluster/gossip_actor.go
@@ -57,7 +57,7 @@ func (ga *GossipActor) Receive(ctx actor.Context) {
 	case *GossipResponse:
 		plog.Error("GossipResponse should not be received by GossipActor") // it should be a response to a request
 	default:
-		plog.Warn("Gossip received unknown message request", log.Message(r))
+		plog.Warn("Gossip received unknown message request", log.Message(r), log.TypeOf("msg_type", r))
 	}
 }
 

--- a/remote/endpoint_writer.go
+++ b/remote/endpoint_writer.go
@@ -112,6 +112,10 @@ func (state *endpointWriter) initializeInternal() error {
 			switch {
 			case errors.Is(err, io.EOF):
 				plog.Debug("EndpointWriter stream completed", log.String("address", state.address))
+				terminated := &EndpointTerminatedEvent{
+					Address: state.address,
+				}
+				state.remote.actorSystem.EventStream.Publish(terminated)
 				break
 			case err != nil:
 				plog.Error("EndpointWriter lost connection", log.String("address", state.address), log.Error(err))

--- a/remote/server.go
+++ b/remote/server.go
@@ -102,7 +102,7 @@ func (r *Remote) Shutdown(graceful bool) {
 		select {
 		case <-c:
 			plog.Info("Stopped Proto.Actor server")
-		case <-time.After(time.Second * 10):
+		case <-time.After(time.Second):
 			r.s.Stop()
 			plog.Info("Stopped Proto.Actor server", log.String("err", "timeout"))
 		}


### PR DESCRIPTION
- Fix gossip loop not stopping on shutdown
- Fix endpoint writer not stopping when the stream ends with `io.EOF`
- Shorter timeout for shutting down the gRPC server gracefully. 