### PR TITLE
Remove extra identity lookup shutdown

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -141,7 +141,6 @@ func (c *Cluster) Shutdown(graceful bool) {
 		// This is to wait ownership transferring complete.
 		time.Sleep(time.Millisecond * 2000)
 		c.MemberList.stopMemberList()
-		c.IdentityLookup.Shutdown()
 		c.Gossip.Shutdown()
 	}
 


### PR DESCRIPTION
Not sure if this is actually breaking anything but at least it would cause some future timed out errors when shutting down.